### PR TITLE
Rework and upgrades

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+volume-data

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+volume-data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Installation procedure documented here:
 # https://help.ubnt.com/hc/en-us/articles/220066768-UniFi-How-to-Install-and-Update-via-APT-on-Debian-or-Ubuntu
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -23,22 +23,17 @@ RUN wget -qO /etc/apt/trusted.gpg.d/unifi-repo.gpg https://dl.ui.com/unifi/unifi
 RUN wget -qO - https://www.mongodb.org/static/pgp/server-3.4.asc | apt-key add -
 RUN echo "deb https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" > /etc/apt/sources.list.d/mongodb-org-3.4.list
 
-# Prevent JDK11 installation
-# RUN apt-mark hold openjdk-11-*
-
 # Prevent services from starting at installation
 RUN echo exit 0 > /usr/sbin/policy-rc.d
 
 # Install Unifi-Controller
 RUN apt-get update -qq \
+    && apt-mark hold openjdk-11-* openjdk-17-* \
     && apt-get install -qq -y \
+       openjdk-8-jre-headless \
        unifi \
     && apt-get clean \
     && rm -rf /var/lib/apt/list/*
-
-# Pipe logs to stdout so "docker logs" can show them
-RUN ln -s /dev/stdout /var/log/unifi/server.log
-RUN ln -s /dev/stdout /var/log/unifi/mongod.log
 
 VOLUME /var/lib/unifi
 
@@ -46,4 +41,4 @@ EXPOSE 8080 8443
 # Are these really needed?
 # EXPOSE 3478/udp 8880 8843 6789 27117 5656-5699/udp 10001/udp 1900/udp
 
-CMD ["/usr/bin/jsvc", "-nodetach" , "-home", "/usr/lib/jvm/java-8-openjdk-amd64", "-cp", "/usr/share/java/commons-daemon.jar:/usr/lib/unifi/lib/ace.jar", "-pidfile", "/var/run/unifi/unifi.pid", "-procname", "unifi", "-outfile", "SYSLOG", "-errfile", "SYSLOG", "-Djava.awt.headless=true", "-Dfile.encoding=UTF-8", "-Xmx1024M", "com.ubnt.ace.Launcher", "start"]
+CMD ["/usr/bin/jsvc", "-nodetach" , "-home", "/usr/lib/jvm/java-8-openjdk-amd64", "-cp", "/usr/share/java/commons-daemon.jar:/usr/lib/unifi/lib/ace.jar", "-pidfile", "/var/run/unifi/unifi.pid", "-procname", "unifi", "-outfile", "/dev/stdout", "-errfile", "/dev/stderr", "-Djava.awt.headless=true", "-Dfile.encoding=UTF-8", "-Xmx1024M", "com.ubnt.ace.Launcher", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM library/ubuntu:16.04
+FROM ubuntu:16.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN apt-get update && apt-get install -y -f \
     wget \
     openjdk-8-jre-headless \
@@ -13,10 +16,10 @@ RUN apt-get update && apt-get install -y -f \
 
 RUN echo exit 0 > /usr/sbin/policy-rc.d
 #RUN export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
-RUN export DEBIAN_FRONTEND="noninteractive"
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
-RUN wget https://dl.ubnt.com/unifi/5.10.25/unifi_sysvinit_all.deb; \ 
-    dpkg -i unifi_sysvinit_all.deb
+
+ADD https://dl.ui.com/unifi/5.12.66/unifi_sysvinit_all.deb /tmp/unifi_sysvinit_all.deb
+RUN dpkg -i /tmp/unifi_sysvinit_all.deb
 
 #COPY unifi.init /usr/lib/unifi/bin/unifi.init
 #RUN chmod +x /usr/lib/unifi/bin/unifi.init

--- a/README.md
+++ b/README.md
@@ -7,6 +7,25 @@ Builds a Docker image for running the Ubiquiti UniFi Controller inside of Docker
 - 8080
 - 8443
 
+## Howto build
+
+`docker build . -t ubiquiti-controller`
+
+## Howto run
+
+In order for it to work well, it requires:
+- to have access to the host's network namespace
+- to have a specific place (volume) to store its data (optional)
+
+```
+docker run -d \
+    --net host \
+    --restart unless-stopped \
+    --name ubiquiti \
+    -v "$(pwd)/volume-data:/var/lib/unifi \
+    ubiquiti-controller
+```
+
 ## About
 
 The base image is from the official Docker library ubuntu:16.04. The default command is to start the UniFi Controller, which was derived from looking at the /etc/init.d/unifi script that the unifi software from Ubiquiti installs in it's Linux package. Added to the cmd line is the '-nodetach' flag so that it runs in forground mode and is the 1st process in the Docker container.

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ docker run -d \
     --net host \
     --restart unless-stopped \
     --name ubiquiti \
-    -v "$(pwd)/volume-data:/var/lib/unifi \
+    -v "$(pwd)"/volume-data:/var/lib/unifi \
     ubiquiti-controller
 ```
 
 ## About
 
-The base image is from the official Docker library ubuntu:16.04. The default command is to start the UniFi Controller, which was derived from looking at the /etc/init.d/unifi script that the unifi software from Ubiquiti installs in it's Linux package. Added to the cmd line is the '-nodetach' flag so that it runs in forground mode and is the 1st process in the Docker container.
+The base image is from the official Docker library ubuntu:18.04. The default command is to start the UniFi Controller, which was derived from looking at the /etc/init.d/unifi script that the unifi software from Ubiquiti installs in it's Linux package. Added to the cmd line is the '-nodetach' flag so that it runs in forground mode and is the 1st process in the Docker container.
 
 Pull requests welcome!
 


### PR DESCRIPTION
- use latest LTS Ubuntu (18.04)
- use Unifi package sources, so at each build we install the latest available
- reduces image size (previously 750MB, now 500MB)
- added a few how-to words in README